### PR TITLE
 fix(server): 학관 검색 시 학생회관 없이 '학관'을 포함하는 검색어 후보만 뜨는 버그 해결

### DIFF
--- a/server.js
+++ b/server.js
@@ -317,17 +317,15 @@ function createQueryConditions(req) {
                              FROM bd_info as b
                              INNER JOIN poi_point as p
                              ON b.bg_name = p.bg_name`;
-    // 입력된 검색어(예: '학')가 bg_name 항목에 속할 경우, 검색어의 인덱스 순으로 (예: 학생회관>대학본부>과학기술관) ㄱㄴㄷ순 정렬
-    const c_org = ` WHERE p.bg_name LIKE '%${req.keyword}%'
+    // 입력된 검색어(예: '학')가 bg_name 또는 nickname 항목에 속할 경우, 검색어의 인덱스 순으로 (예: 학생회관>대학본부>과학기술관) ㄱㄴㄷ순 정렬
+    const c_kor = ` WHERE p.bg_name LIKE '%${req.keyword}%'
+                    OR p.nickname LIKE '%${req.keyword}%'
                     ORDER BY POSITION('${req.keyword}' IN p.bg_name) ASC,
                     p.bg_name COLLATE "ko_KR.utf8" ASC`;
-    // 입력된 검색어가 nickname 항목에 속할 경우 ㄱㄴㄷ순 정렬
-    const c_nick = ` WHERE p.nickname LIKE '${req.keyword}'
-                    ORDER BY POSITION('${req.keyword}' IN p.nickname) ASC, p.nickname COLLATE "ko_KR.utf8" ASC`;
     // 입력된 검색어가 eng_name 항목에 속할 경우 ABC순 정렬
     const c_eng = ` WHERE p.eng_name ILIKE '%${req.keyword}%'
                     ORDER BY eng_name ASC`;
-    return [commonString+c_org, commonString+c_nick, commonString+c_eng];
+    return [commonString+c_kor, commonString+c_eng];
 }
 
 async function getBuildingInfoAsync(conditions) {


### PR DESCRIPTION
- nickname(별칭) 검색 보다 bg_name 검색 우선순위가 높고, 우선순위가 높은 조건의 쿼리 결과가 존재할 시 다른 검색은 하지 않기 때문에 이런 버그가 나타남
- 각 속성에서, 즉 bg_name / nickname / eng_name 총 세 가지 조건으로 각각 검색하던 방식에서 bg_name이랑 nickname을 조건절을 병합
- 어차피 둘 다 가나다 순 정렬
- 단 bg_name 속성에서 오름차순으로