### PR TITLE
fix(server): 길찾기 알고리즘 쿼리문 수정 및 ConvCateId 객체 수정

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ app.use(express.json());
 async function str2id(userReq1) {
     try {
         let AllPoints = [];
-        let str2idQuery = 'SELECT node_id from "node" WHERE  "node".bulid_name = $1';
+        let str2idQuery = 'SELECT node_id from "node" WHERE  "node".bulid_name = $1 AND "node".node_att = 2';
         let str2idQuery1 = `SELECT n.node_id
                            FROM node as n
                            JOIN convenient as c
@@ -229,12 +229,15 @@ const ConvCateId = {
     'library': 17,      //도서관
     'vendingMachine': 18,    //자판기
     'toilet': 19, //장애인 화장실
-    'restaurant': 20,//식당
-    'unmanned civil service': 21, //무인민원발급가
-    'rooftop garden': 22, //옥상정원
-    'shower room': 23, //샤워실
-    'sports': '10, 11, 12',
-    'dining': '8, 20',
+    'unmanned civil service': 20, //무인민원발급기
+    'rooftop garden': 21, //옥상정원
+    'shower room': 22, //샤워실
+    'foot volley': 23, // 족구장
+    'book store': 24, // 서점
+    'restaurant': 25,// 식당
+    'squash': 26, // 스쿼시
+    'sports': '10, 23, 11, 12',
+    'dining': '8, 25',
     'cafe&store': '2, 4',
 }
 


### PR DESCRIPTION
- 실내 도면 띄우는 과정에서 실내인 노드들이 bulid_name이 null이 아니어야 함
- 그러나  값을 채우는 순간, 예를 들어 출발지로 21세기관 입력 시 21세기관 출입구 뿐만 아니라 21세기관 실내의 모든 노드들이 검색 후보로 들어가게 됨
- 따라서 사용자 입력어가 bulid_name과 일치할 경우 출입구만 찾도록 node_att=2 조건문을 추가함

- 실제로 DB의 convenient테이블 conv_cate의 값과 ConvCateId 객체의 값이 일치하지 않는 경우가 있어 수정